### PR TITLE
Added case platform windows

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'joe@chef.io'
 license 'Apache 2.0'
 description 'Hardening cookbook for Windows 2012 R2'
 long_description 'Remediates critical issues identified by the DevSec Windows baseline'
-version '0.8.0'
-
+version '0.8.1'
+supports 'windows'
 depends 'windows-security-policy'

--- a/recipes/access.rb
+++ b/recipes/access.rb
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2016 Joe Gardiner, All Rights Reserved.
 
+return unless node['platform_family'] == 'windows'
+
 # All Shares are Configured to Prevent Anonymous Access
 # windows-baseline: windows-base-103
 registry_key 'HKLM\\System\\CurrentControlSet\\Services\\LanManServer\\Parameters' do

--- a/recipes/audit.rb
+++ b/recipes/audit.rb
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2016 Joe Gardiner, All Rights Reserved.
 
+return unless node['platform_family'] == 'windows'
+
 # Configure System Event Log (Application)
 # windows-baseline: windows-audit-100
 registry_key 'HKLM\\Software\\Policies\\Microsoft\\Windows\\EventLog\\Application' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2016 Joe Gardiner, All Rights Reserved.
 
+return unless node['platform_family'] == 'windows'
+
 include_recipe 'windows-hardening::password_policy'
 include_recipe 'windows-hardening::security_policy'
 include_recipe 'windows-hardening::user_rights'

--- a/recipes/enable_winrm_access.rb
+++ b/recipes/enable_winrm_access.rb
@@ -4,8 +4,9 @@
 #
 # Copyright (c) 2016 Joe Gardiner, All Rights Reserved.
 
-# Winrm access is required for agentless verification. Add this recipe as required.
+return unless node['platform_family'] == 'windows'
 
+# Winrm access is required for agentless verification. Add this recipe as required.
 powershell_script 'Remote Management' do
   code 'Set-NetFirewallRule WINRM-HTTP-In-TCP-PUBLIC -RemoteAddress "any"'
 end

--- a/recipes/ie.rb
+++ b/recipes/ie.rb
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2016 Joe Gardiner, All Rights Reserved.
 
+return unless node['platform_family'] == 'windows'
+
 # IE 64-bit tab
 # windows-baseline: windows-ie-101
 registry_key 'HKLM\\Software\\Policies\\Microsoft\\Internet Explorer\\Main' do

--- a/recipes/password_policy.rb
+++ b/recipes/password_policy.rb
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2016 Joe Gardiner, All Rights Reserved.
 
+return unless node['platform_family'] == 'windows'
+
 # Set Enforce password history to 24 or more passwords
 # cis: enforce-password-history 1.1.1
 execute 'Password history' do

--- a/recipes/rdp.rb
+++ b/recipes/rdp.rb
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2016 Joe Gardiner, All Rights Reserved.
 
+return unless node['platform_family'] == 'windows'
+
 # Windows Remote Desktop Configured to Always Prompt for Password
 # windows-baseline: windows-rdp-100
 registry_key 'HKLM\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services' do

--- a/recipes/security_policy.rb
+++ b/recipes/security_policy.rb
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2016 Joe Gardiner, All Rights Reserved.
 
+return unless node['platform_family'] == 'windows'
+
 # cis: account-lockout-duration 1.2.1,
 # cis: reset-account-lockout 1.2.3
 # windows-baseline: windows-account-104


### PR DESCRIPTION
Wrapped all policy in case platform windows to. This allows this hardening cookbook to be added to a remediation role that can be used to address Windows and other platforms.

Verified 100% coverage against test profile - https://github.com/dev-sec/windows-baseline