### PR TITLE
windows nano support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,11 @@ platforms:
   - name: windows-2016
     driver_config:
       box: mwrock/Windows2016
+  - name: windows-2016-nano
+    driver_config:
+      box: mwrock/WindowsNano
+    provisioner:
+      install_msi_url: https://s3-us-west-2.amazonaws.com/nano-chef-client/chef-12.14.60.appx
 
 suites:
   - name: default

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This cookbook provides recipes for ensuring that a Windows 2012 R2 system is com
 - Windows Server 2012
 - Windows Server 2012 R2
 - Windows Server 2016
+- Windows Server 2016 Nano Server
 
 ## Coding guidelines
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,7 @@
+# encoding: utf-8
+#
+# Cookbook Name:: windows-hardening
+# Attributes:: default
+
+# set this value if you want to harden terminal services
+default['windows_hardening']['rdp']['harden'] = true

--- a/attributes/sec_policy.rb
+++ b/attributes/sec_policy.rb
@@ -5,6 +5,7 @@ default['security_policy']['database']['name'] = 'hardening.sdb'
 
 # System access settings
 # Nil value means nothing will be written to the security policy template.
+default['security_policy']['access']['PasswordComplexity'] = 1
 default['security_policy']['access']['LockoutBadCount'] = 3
 default['security_policy']['access']['ResetLockoutCount'] = 15
 default['security_policy']['access']['LockoutDuration'] = 15

--- a/recipes/access.rb
+++ b/recipes/access.rb
@@ -6,6 +6,17 @@
 
 return unless node['platform_family'] == 'windows'
 
+# Anonymous Access to Windows Shares and Named Pipes is Disallowed
+# windows-baseline: windows-base-102
+registry_key 'HKLM\\System\\CurrentControlSet\\Services\\LanManServer\\Parameters' do
+  values [{
+    name: 'RestrictNullSessAccess',
+    type: :dword,
+    data: 1
+  }]
+  action :create_if_missing
+end
+
 # All Shares are Configured to Prevent Anonymous Access
 # windows-baseline: windows-base-103
 registry_key 'HKLM\\System\\CurrentControlSet\\Services\\LanManServer\\Parameters' do

--- a/recipes/audit.rb
+++ b/recipes/audit.rb
@@ -80,6 +80,19 @@ file 'C:\appGroupMngmtAudit.lock' do
   action :nothing
 end
 
+# Audit Computer Account Management
+# windows-baseline: windows-audit-205
+execute 'Audit Computer Account Management' do
+  command 'AuditPol /Set /SubCategory:"Computer Account Management" /Failure:Enable /Success:Enable'
+  action :run
+  not_if { ::File.exist?('C:\appAccountMngmtAudit.lock') }
+  notifies :create, 'file[C:\appAccountMngmtAudit.lock]', :immediately
+end
+
+file 'C:\appAccountMngmtAudit.lock' do
+  action :nothing
+end
+
 # Audit Distributed Group Management
 # windows-baseline: windows-audit-206
 execute 'Audit Distributed Group Management' do

--- a/recipes/rdp.rb
+++ b/recipes/rdp.rb
@@ -6,24 +6,28 @@
 
 return unless node['platform_family'] == 'windows'
 
-# Windows Remote Desktop Configured to Always Prompt for Password
-# windows-baseline: windows-rdp-100
-registry_key 'HKLM\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services' do
-  values [{
-    name: 'fPromptForPassword',
-    type: :dword,
-    data: 1
-  }]
-  action :create
-end
+if node['windows_hardening']['rdp']['harden'] == true
+  # Windows Remote Desktop Configured to Always Prompt for Password
+  # windows-baseline: windows-rdp-100
+  registry_key 'HKLM\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services' do
+    values [{
+      name: 'fPromptForPassword',
+      type: :dword,
+      data: 1
+    }]
+    recursive true
+    action :create
+  end
 
-# Strong Encryption for Windows Remote Desktop Required
-# windows-baseline: windows-rdp-101
-registry_key 'HKLM\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services' do
-  values [{
-    name: 'MinEncryptionLevel',
-    type: :dword,
-    data: 3
-  }]
-  action :create
+  # Strong Encryption for Windows Remote Desktop Required
+  # windows-baseline: windows-rdp-101
+  registry_key 'HKLM\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services' do
+    values [{
+      name: 'MinEncryptionLevel',
+      type: :dword,
+      data: 3
+    }]
+    recursive true
+    action :create
+  end
 end


### PR DESCRIPTION
This PR adds Windows Nano support to this cookbook:

- added Windows Nano as platform for test-kitchen
- rdp hardening is optional now
- Fix: set `PasswordComplexity` correctly (default was just right before)
- Fix: set `RestrictNullSessAccess` correctly (default was just right before)