### PR TITLE
Fix Empty Recipe & CIS EventLog Size Requirements

### DIFF
--- a/recipes/audit.rb
+++ b/recipes/audit.rb
@@ -12,7 +12,7 @@ registry_key 'HKLM\\Software\\Policies\\Microsoft\\Windows\\EventLog\\Applicatio
   values [{
     name: 'MaxSize',
     type: :dword,
-    data: 1
+    data: 4_194_240
   }]
   recursive true
   action :create
@@ -24,7 +24,7 @@ registry_key 'HKLM\\Software\\Policies\\Microsoft\\Windows\\EventLog\\Security' 
   values [{
     name: 'MaxSize',
     type: :dword,
-    data: 1
+    data: 4_194_240
   }]
   recursive true
   action :create
@@ -36,7 +36,7 @@ registry_key 'HKLM\\Software\\Policies\\Microsoft\\Windows\\EventLog\\Setup' do
   values [{
     name: 'MaxSize',
     type: :dword,
-    data: 1
+    data: 4_194_240
   }]
   recursive true
   action :create
@@ -48,7 +48,7 @@ registry_key 'HKLM\\Software\\Policies\\Microsoft\\Windows\\EventLog\\System' do
   values [{
     name: 'MaxSize',
     type: :dword,
-    data: 1
+    data: 4_194_240
   }]
   recursive true
   action :create

--- a/recipes/user_rights.rb
+++ b/recipes/user_rights.rb
@@ -1,0 +1,1 @@
+# Encoding: UTF-8


### PR DESCRIPTION
Empty recipes can cause errors when provisioning with Packer & WinRM

```
    amazon-ebs: [2018-12-07T04:02:16+00:00] ERROR: Running exception handlers
    amazon-ebs: Running handlers complete
    amazon-ebs: [2018-12-07T04:02:16+00:00] ERROR: Exception handlers complete
    amazon-ebs: Chef Client failed. 0 resources updated in 04 seconds
    amazon-ebs: [2018-12-07T04:02:16+00:00] FATAL: Stacktrace dumped to c:/windows/temp/packer-chef-solo/local-mode-cache/cache/chef-stacktrace.out
    amazon-ebs: [2018-12-07T04:02:16+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
    amazon-ebs: [2018-12-07T04:02:16+00:00] FATAL: SyntaxError: c:/windows/temp/packer-chef-solo/local-mode-cache/cache/cookbooks/windows-hardening/recipes/user_rights.rb:1: invalid multibyte char (UTF-8)
```