### PR TITLE
Take out legacy metadata support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache 2.0'
 description 'Hardening cookbook for Windows 2012 R2'
 long_description 'Remediates critical issues identified by the DevSec Windows baseline'
 version '0.9.1'
-source_url 'https://github.com/dev-sec/chef-windows-hardening' if respond_to?(:source_url)
-issues_url 'https://github.com/dev-sec/chef-windows-hardening/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/dev-sec/chef-windows-hardening'
+issues_url 'https://github.com/dev-sec/chef-windows-hardening/issues'
 supports 'windows'
 depends 'windows-security-policy'


### PR DESCRIPTION
It's no longer necessary to gate the issues_url and source_url like this.