### PR TITLE
Fix for Chef 16+ custom resource change

### DIFF
--- a/resources/password_policy.rb
+++ b/resources/password_policy.rb
@@ -1,4 +1,5 @@
 resource_name :password_policy
+provides :password_policy
 
 property :policy_name, String, name_property: true
 property :policy_command, String, required: true


### PR DESCRIPTION
In Chef 16, we need to have provides also.

https://docs.chef.io/custom_resources/#provides

```
FATAL: NoMethodError: undefined method `password_policy' for cookbook: windows-hardening, recipe: password_policy :Chef::Recipe
```